### PR TITLE
Do not depend on a specific custom_components path, fixes #1

### DIFF
--- a/custom_components/magister_school/api.py
+++ b/custom_components/magister_school/api.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import logging
+from pathlib import Path
 from .const import CONF_SCHOOL, CONF_USER, CONF_PASS
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,7 +16,8 @@ class MagisterAPI:
         self.authcode = DEFAULT_AUTHCODE
 
     def get_data(self):
-        script_path = "/config/custom_components/magister_school/magister.py"
+        script_dir = Path(__file__).resolve().parent
+        script_path = str(script_dir) + "/magister.py"
         cmd = [
             "python3", script_path,
             "--json",


### PR DESCRIPTION
magister.py and api.py are in the same folder.

Closes #1 