### PR TITLE
Add TOTP two-factor authentication support

### DIFF
--- a/custom_components/magister_school/__init__.py
+++ b/custom_components/magister_school/__init__.py
@@ -15,12 +15,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Magister from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     
-    # Create coordinator
+    # Create coordinator (pass totp_secret if present)
     coordinator = MagisterDataUpdateCoordinator(
         hass,
         entry.data["school"],
         entry.data["user"],
-        entry.data["pass"]
+        entry.data["pass"],
+        totp_secret=entry.data.get("totp_secret"),
     )
     
     # Store coordinator

--- a/custom_components/magister_school/api.py
+++ b/custom_components/magister_school/api.py
@@ -13,11 +13,12 @@ class AuthenticationRequired(Exception):
     pass
 
 class MagisterAPI:
-    def __init__(self, school, user, password):
+    def __init__(self, school, user, password, totp_secret=None):
         self.school = school
         self.user = user
         self.password = password
         self.authcode = DEFAULT_AUTHCODE
+        self.totp_secret = totp_secret
 
     def get_data(self):
         script_dir = Path(__file__).resolve().parent
@@ -31,6 +32,9 @@ class MagisterAPI:
             "--authcode", self.authcode
         ]
 
+        if self.totp_secret:
+            cmd += ["--totp-secret", self.totp_secret]
+
         try:
             result = subprocess.run(
                 cmd,
@@ -39,13 +43,15 @@ class MagisterAPI:
                 timeout=30,
                 check=True,
             )
+            if not result.stdout.strip():
+                raise AuthenticationRequired("Login failed: no output from script (wrong credentials or TOTP secret)")
             try:
                 return json.loads(result.stdout)
             except json.JSONDecodeError as e:
                 out = (result.stdout or "") + (result.stderr or "")
                 _LOGGER.error("Ongeldige JSON van Magister script: %s, output: %s", e, out)
                 low = out.lower()
-                if any(tok in low for tok in ["visit website", "redirect url does not contain a fragment", "could not get account info", "requested -> visit website", "change password"]):
+                if any(tok in low for tok in ["visit website", "redirect url does not contain a fragment", "could not get account info", "requested -> visit website", "change password", "totp challenge failed", "softtoken challenge failed", "2fa (totp) is required", "2fa (softtoken) is required"]):
                     raise AuthenticationRequired(out)
                 raise
 
@@ -56,7 +62,7 @@ class MagisterAPI:
             out = (e.stdout or "") + (e.stderr or "")
             _LOGGER.error("Magister script error: %s", out)
             low = out.lower()
-            if any(tok in low for tok in ["visit website", "redirect url does not contain a fragment", "could not get account info", "requested -> visit website", "change password"]):
+            if any(tok in low for tok in ["visit website", "redirect url does not contain a fragment", "could not get account info", "requested -> visit website", "change password", "totp challenge failed", "softtoken challenge failed", "2fa (totp) is required", "2fa (softtoken) is required"]):
                 raise AuthenticationRequired(out)
             raise
         except Exception as e:

--- a/custom_components/magister_school/config_flow.py
+++ b/custom_components/magister_school/config_flow.py
@@ -17,7 +17,9 @@ async def validate_input(hass, data):
     if not school or not user or not password:
         raise ValueError("invalid_auth")
 
-    api = MagisterAPI(school, user, password)
+    totp_secret = data.get("totp_secret") or None
+
+    api = MagisterAPI(school, user, password, totp_secret=totp_secret)
     try:
         await hass.async_add_executor_job(api.get_data)
     except AuthenticationRequired:
@@ -65,6 +67,7 @@ class MagisterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required("school"): str,
                 vol.Required("user"): str,
                 vol.Required("pass"): str,
+                vol.Optional("totp_secret"): str,
             }
         )
 
@@ -81,8 +84,16 @@ class MagisterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                await validate_input(self.hass, {"school": entry.data["school"], "user": entry.data["user"], "pass": user_input["pass"]})
+                totp_secret = user_input.get("totp_secret") or entry.data.get("totp_secret")
+                await validate_input(self.hass, {
+                    "school": entry.data["school"],
+                    "user": entry.data["user"],
+                    "pass": user_input["pass"],
+                    "totp_secret": totp_secret,
+                })
                 new_data = {**entry.data, "pass": user_input["pass"]}
+                if "totp_secret" in user_input:
+                    new_data["totp_secret"] = user_input["totp_secret"] or None
                 self.hass.config_entries.async_update_entry(entry, data=new_data)
                 await self.hass.config_entries.async_reload(entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
@@ -94,7 +105,10 @@ class MagisterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth",
-            data_schema=vol.Schema({vol.Required("pass"): str}),
+            data_schema=vol.Schema({
+                vol.Required("pass"): str,
+                vol.Optional("totp_secret"): str,
+            }),
             errors=errors,
         )
 

--- a/custom_components/magister_school/config_flow.py
+++ b/custom_components/magister_school/config_flow.py
@@ -77,9 +77,13 @@ class MagisterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_reauth(self, user_input=None):
+    async def async_step_reauth(self, entry_data=None):
         """Handel re-authenticatie af voor bestaande config entries."""
-        entry = self.hass.config_entries.async_get_entry(self.context.get("entry_id"))
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Toon formulier voor re-authenticatie."""
+        entry = self._get_reauth_entry()
         errors = {}
 
         if user_input is not None:
@@ -104,7 +108,7 @@ class MagisterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors["base"] = "cannot_connect"
 
         return self.async_show_form(
-            step_id="reauth",
+            step_id="reauth_confirm",
             data_schema=vol.Schema({
                 vol.Required("pass"): str,
                 vol.Optional("totp_secret"): str,

--- a/custom_components/magister_school/coordinator.py
+++ b/custom_components/magister_school/coordinator.py
@@ -29,7 +29,7 @@ class MagisterDataUpdateCoordinator(DataUpdateCoordinator):
             return data
         except AuthenticationRequired as err:
             _LOGGER.error("Authenticatie vereist voor Magister: %s", err)
-            await persistent_notification.async_create(
+            persistent_notification.async_create(
                 self.hass,
                 "Mogelijk nieuw wachtwoord of onjuiste 2FA-sleutel voor Magister. Ga naar Configuratie → Integrations → Magister om opnieuw in te loggen.",
                 title="Magister - Re-authentication required",

--- a/custom_components/magister_school/coordinator.py
+++ b/custom_components/magister_school/coordinator.py
@@ -12,8 +12,8 @@ _LOGGER = logging.getLogger(__name__)
 class MagisterDataUpdateCoordinator(DataUpdateCoordinator):
     """Coordinator voor Magister data updates."""
 
-    def __init__(self, hass: HomeAssistant, school: str, username: str, password: str):
-        self.api = MagisterAPI(school, username, password)
+    def __init__(self, hass: HomeAssistant, school: str, username: str, password: str, totp_secret: str = None):
+        self.api = MagisterAPI(school, username, password, totp_secret=totp_secret)
         
         super().__init__(
             hass,
@@ -31,7 +31,7 @@ class MagisterDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Authenticatie vereist voor Magister: %s", err)
             await persistent_notification.async_create(
                 self.hass,
-                "Mogelijk nieuw wachtwoord nodig voor Magister. Ga naar Configuratie → Integrations → Magister om opnieuw in te loggen.",
+                "Mogelijk nieuw wachtwoord of onjuiste 2FA-sleutel voor Magister. Ga naar Configuratie → Integrations → Magister om opnieuw in te loggen.",
                 title="Magister - Re-authentication required",
             )
             raise ConfigEntryAuthFailed from err

--- a/custom_components/magister_school/magister.py
+++ b/custom_components/magister_school/magister.py
@@ -19,9 +19,13 @@ import base64
 
 def generate_totp(secret: str, digits: int = 6, period: int = 30) -> str:
     """Generate a TOTP code from a base32-encoded secret."""
-    secret_clean = secret.upper().replace(' ', '').replace('-', '')
+    # Normalize: remove spaces, dashes, uppercase, strip padding
+    secret_clean = secret.upper().replace(' ', '').replace('-', '').rstrip('=')
+    # Only keep valid base32 characters
+    secret_clean = ''.join(c for c in secret_clean if c in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567')
+    # Add padding if needed
     padding = (8 - len(secret_clean) % 8) % 8
-    secret_bytes = base64.b32decode(secret_clean + '=' * padding)
+    secret_bytes = base64.b32decode(secret_clean + '=' * padding, casefold=True)
     counter = int(time.time()) // period
     counter_bytes = struct.pack('>Q', counter)
     h = hmac.new(secret_bytes, counter_bytes, hashlib.sha1).digest()

--- a/custom_components/magister_school/magister.py
+++ b/custom_components/magister_school/magister.py
@@ -10,6 +10,25 @@ import os
 import traceback
 from pathlib import Path
 import argparse
+import hmac
+import hashlib
+import struct
+import time
+import base64
+
+
+def generate_totp(secret: str, digits: int = 6, period: int = 30) -> str:
+    """Generate a TOTP code from a base32-encoded secret."""
+    secret_clean = secret.upper().replace(' ', '').replace('-', '')
+    padding = (8 - len(secret_clean) % 8) % 8
+    secret_bytes = base64.b32decode(secret_clean + '=' * padding)
+    counter = int(time.time()) // period
+    counter_bytes = struct.pack('>Q', counter)
+    h = hmac.new(secret_bytes, counter_bytes, hashlib.sha1).digest()
+    offset = h[-1] & 0x0F
+    code = struct.unpack('>I', h[offset:offset + 4])[0] & 0x7FFFFFFF
+    return str(code % (10 ** digits)).zfill(digits)
+
 
 def dehtml(html):
     """
@@ -308,14 +327,39 @@ class Magister:
         self.logprint("\n---- password ----")
         r = self.httpreq(f"https://{self.magisterserver}/challenges/password", json.dumps(d))
 
+        # Handle 2FA challenge after password
         if not r.get('redirectURL') or r.get('error'):
-            if r.get('action'):
+            action = r.get('action', '')
+            if action in ('totp', 'softtoken'):
+                self.logprint(f"\n---- {action} ----")
+                totp_secret = getattr(self.args, 'totp_secret', None)
+                if not totp_secret:
+                    if not getattr(self.args, "json", False):
+                        print(f"2FA ({action}) is required but no totp_secret was provided")
+                    return False
+                otp_code = generate_totp(totp_secret)
+                if self.args.verbose and not getattr(self.args, "json", False):
+                    print(f"-> Generated OTP code: {otp_code}")
+                otp_payload = dict(d)
+                if action == "softtoken":
+                    otp_payload["code"] = otp_code
+                    endpoint = "soft-token"
+                else:
+                    otp_payload["otp"] = otp_code
+                    endpoint = action
+                r = self.httpreq(f"https://{self.magisterserver}/challenges/{endpoint}", json.dumps(otp_payload))
+                if not r.get('redirectURL') or r.get('error'):
+                    if not getattr(self.args, "json", False):
+                        print(f"{action} challenge failed: '{r.get('error', 'no redirectURL')}'")
+                    return False
+            elif action:
                 if not getattr(self.args, "json", False):
-                    print("'%s' requested -> visit website" % r['action'])
+                    print("'%s' requested -> visit website" % action)
                 return False
-            if not getattr(self.args, "json", False):
-                print("ERROR '%s'" % r.get('error'))
-            return False
+            else:
+                if not getattr(self.args, "json", False):
+                    print("ERROR '%s'" % r.get('error'))
+                return False
 
         self.logprint("\n---- callback ----")
         url, html = self.httpredirurl(f"https://{self.magisterserver}" + r["redirectURL"])
@@ -459,6 +503,7 @@ def main():
     parser.add_argument('--username', help=argparse.SUPPRESS)
     parser.add_argument('--password', help=argparse.SUPPRESS)
     parser.add_argument("--authcode", help=argparse.SUPPRESS)
+    parser.add_argument('--totp-secret', dest='totp_secret', default=None, help=argparse.SUPPRESS)
     parser.add_argument('--schoolserver', help=argparse.SUPPRESS)
     parser.add_argument('--magisterserver', default='accounts.magister.net', help=argparse.SUPPRESS)
     args = parser.parse_args()

--- a/custom_components/magister_school/strings.json
+++ b/custom_components/magister_school/strings.json
@@ -18,6 +18,14 @@
             "pass": "Wachtwoord",
             "totp_secret": "2FA geheime sleutel (optioneel)"
           }
+        },
+        "reauth_confirm": {
+          "title": "Magister opnieuw inloggen",
+          "description": "Voer je nieuwe wachtwoord in. Laat de 2FA-sleutel leeg om de bestaande instelling te behouden.",
+          "data": {
+            "pass": "Wachtwoord",
+            "totp_secret": "2FA geheime sleutel (optioneel)"
+          }
         }
       },
       "error": {

--- a/custom_components/magister_school/strings.json
+++ b/custom_components/magister_school/strings.json
@@ -7,16 +7,27 @@
           "data": {
             "school": "School (bijv. 'trevianum')",
             "user": "Gebruikersnaam (meestal e-mailadres of leerlingnummer)",
-            "pass": "Wachtwoord"
+            "pass": "Wachtwoord",
+            "totp_secret": "2FA geheime sleutel (optioneel, alleen bij tweestapsverificatie)"
+          }
+        },
+        "reauth": {
+          "title": "Magister opnieuw inloggen",
+          "description": "Voer je nieuwe wachtwoord in. Laat de 2FA-sleutel leeg om de bestaande instelling te behouden.",
+          "data": {
+            "pass": "Wachtwoord",
+            "totp_secret": "2FA geheime sleutel (optioneel)"
           }
         }
       },
       "error": {
-        "invalid_auth": "Ongeldige gebruikersnaam of wachtwoord.",
+        "invalid_auth": "Ongeldige gebruikersnaam, wachtwoord of 2FA-sleutel.",
+        "cannot_connect": "Kan geen verbinding maken met Magister.",
         "unknown": "Onbekende fout, controleer de logbestanden."
       },
       "abort": {
-        "already_configured": "Deze Magister gebruiker is al geconfigureerd."
+        "already_configured": "Deze Magister gebruiker is al geconfigureerd.",
+        "reauth_successful": "Opnieuw inloggen geslaagd."
       }
     },
     "options": {

--- a/custom_components/magister_school/translations/en.json
+++ b/custom_components/magister_school/translations/en.json
@@ -5,9 +5,18 @@
         "title": "Magister Configuration",
         "description": "Enter your Magister login credentials",
         "data": {
-          "school": "School", 
+          "school": "School",
           "user": "Username",
-          "pass": "Password"
+          "pass": "Password",
+          "totp_secret": "2FA secret key (optional, only for two-factor authentication)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Magister Re-authentication",
+        "description": "Enter your new password. Leave the 2FA field empty to keep the existing setting.",
+        "data": {
+          "pass": "Password",
+          "totp_secret": "2FA secret key (optional)"
         }
       }
     },

--- a/custom_components/magister_school/translations/nl.json
+++ b/custom_components/magister_school/translations/nl.json
@@ -6,13 +6,22 @@
         "description": "Voer je Magister inloggegevens in",
         "data": {
           "school": "School",
-          "user": "Gebruikersnaam", 
-          "pass": "Wachtwoord"
+          "user": "Gebruikersnaam",
+          "pass": "Wachtwoord",
+          "totp_secret": "2FA geheime sleutel (optioneel, alleen bij tweestapsverificatie)"
+        }
+      },
+      "reauth": {
+        "title": "Magister opnieuw inloggen",
+        "description": "Voer je nieuwe wachtwoord in. Laat de 2FA-sleutel leeg om de bestaande instelling te behouden.",
+        "data": {
+          "pass": "Wachtwoord",
+          "totp_secret": "2FA geheime sleutel (optioneel)"
         }
       }
     },
     "error": {
-      "invalid_auth": "Ongeldige inloggegevens",
+      "invalid_auth": "Ongeldige gebruikersnaam, wachtwoord of 2FA-sleutel.",
       "cannot_connect": "Kan geen verbinding maken met Magister",
       "unknown": "Onverwachte fout opgetreden",
       "timeout": "Time-out bij verbinden met Magister"

--- a/custom_components/magister_school/translations/nl.json
+++ b/custom_components/magister_school/translations/nl.json
@@ -18,6 +18,14 @@
           "pass": "Wachtwoord",
           "totp_secret": "2FA geheime sleutel (optioneel)"
         }
+      },
+      "reauth_confirm": {
+        "title": "Magister opnieuw inloggen",
+        "description": "Voer je nieuwe wachtwoord in. Laat de 2FA-sleutel leeg om de bestaande instelling te behouden.",
+        "data": {
+          "pass": "Wachtwoord",
+          "totp_secret": "2FA geheime sleutel (optioneel)"
+        }
       }
     },
     "error": {


### PR DESCRIPTION
## Summary

This PR enables Magister account authentication for users with two-factor authentication enabled. When the server returns a `totp` or `softtoken` action after password verification, the integration now generates a one-time code automatically using the stored secret key.

**Key Feature:** Users provide their authenticator app's base32-encoded secret during setup—not the 6-digit code. The integration uses this to generate fresh codes at each login without manual intervention. The field is optional; accounts without 2FA are unaffected.

### Files changed

- **magister.py** — `generate_totp()` function (uses Python standard library only), 2FA challenge handling in `login()`
- **api.py** — Forwards `totp_secret` parameter, detects 2FA failures, validates output
- **config_flow.py** — Optional `totp_secret` input field for setup and re-authentication; uses modern `_get_reauth_entry()` API
- **coordinator.py** / **__init__.py** — Threads `totp_secret` from configuration through the API layer
- **strings.json** / **translations/nl.json** / **translations/en.json** — Language labels and `reauth_confirm` step

### Compatibility fixes included

- **HA 2025.x+ reauth flow**: Uses the modern two-step reauth pattern (`async_step_reauth` + `async_step_reauth_confirm`) with `self._get_reauth_entry()` instead of the deprecated `self.context.get("entry_id")` which causes a 500 error in recent HA versions.
- **Python 3.14 base32 decoding**: Stricter base32 validation in Python 3.14 could reject some TOTP secrets. The `generate_totp()` function now strips invalid characters and uses `casefold=True` for compatibility.
- **persistent_notification.async_create**: No longer awaitable in recent HA versions; removed the `await` to prevent `"'NoneType' object can't be awaited"` errors.

### Known issue: Magister FIDO passkey promo

Magister may prompt users with a `pairfidopromo` action after login, asking them to set up a FIDO passkey. This is a promotional/optional prompt, but the integration cannot skip it automatically.

**Workaround:** If the integration fails to authenticate after setup, log in to Magister via a web browser, dismiss/skip the FIDO passkey promotion when prompted, and then restart Home Assistant. The integration will authenticate successfully after the promo has been dismissed.