### PR TITLE
Extra agenda sensors for start and end of school days

### DIFF
--- a/.local/config.sh
+++ b/.local/config.sh
@@ -1,0 +1,5 @@
+export HA_HOST="192.168.2.106"      # SMB hostname or IP
+export HA_URL="http://homeassistant.local:8123"
+export HA_USER="homeassistant"
+export HA_PASS="bunnik"
+export HA_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjODIyYmQ5YTljMWM0OGMwYmMwMjFiMzIxNjNjYTE0OCIsImlhdCI6MTc3NTkwMjQyMSwiZXhwIjoyMDkxMjYyNDIxfQ.2AGsJvkzZ6Da7X_4v53hmxyMDuCnY3KfnmtqeIFOB04"

--- a/.local/config.sh.example
+++ b/.local/config.sh.example
@@ -1,0 +1,5 @@
+export HA_HOST="homeassistant.local"      # SMB hostname or IP
+export HA_URL="http://homeassistant.local:8123"
+export HA_USER="your_smb_username"
+export HA_PASS="your_smb_password"
+export HA_TOKEN="your_long_lived_access_token"

--- a/.local/deploy-homeassistant.sh
+++ b/.local/deploy-homeassistant.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Deploy custom_components/magister_school to Home Assistant over SMB, then restart Core.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG="$(dirname "$0")/config.sh"
+
+[[ -f "$CONFIG" ]] || { echo "Missing .local/config.sh — copy from .local/config.sh.example" >&2; exit 1; }
+# shellcheck source=/dev/null
+source "$CONFIG"
+
+: "${HA_HOST:?Set HA_HOST in .local/config.sh}"
+: "${HA_URL:?Set HA_URL in .local/config.sh}"
+: "${HA_USER:?Set HA_USER in .local/config.sh}"
+: "${HA_PASS:?Set HA_PASS in .local/config.sh}"
+: "${HA_TOKEN:?Set HA_TOKEN in .local/config.sh}"
+
+COMPONENT="magister_school"
+SRC="$ROOT/custom_components/$COMPONENT"
+
+[[ -d "$SRC" ]] || { echo "Missing: $SRC" >&2; exit 1; }
+command -v rsync >/dev/null || { echo "rsync not found" >&2; exit 1; }
+command -v smbclient >/dev/null || { echo "smbclient not found — brew install samba" >&2; exit 1; }
+command -v curl >/dev/null || { echo "curl not found" >&2; exit 1; }
+
+export SMB_CONF_PATH="${SMB_CONF_PATH:-/dev/null}"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+rsync -a --delete \
+  --exclude '.DS_Store' --exclude '__pycache__' --exclude '*.pyc' --exclude '._*' \
+  "$SRC/" "$STAGE/$COMPONENT/"
+
+echo "Uploading $COMPONENT to //$HA_HOST/config ..."
+set +e
+smbclient "//$HA_HOST/config" -U "${HA_USER}%${HA_PASS}" -m SMB3 -q \
+  -c "lcd \"$STAGE\"; cd custom_components; recurse; prompt; mput $COMPONENT" \
+  2> >(grep -v 'NT_STATUS_OBJECT_NAME_COLLISION' >&2)
+smb_rc=$?
+set -e
+[[ "$smb_rc" -eq 0 ]] || { echo "smbclient failed (exit $smb_rc)" >&2; exit 1; }
+
+echo "Restarting Home Assistant..."
+curl_rc=0
+code=$(curl -sS -m 120 -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer ${HA_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST -d "{}" \
+  "${HA_URL%/}/api/services/homeassistant/restart") || curl_rc=$?
+
+if [[ "$curl_rc" -eq 52 || "$curl_rc" -eq 56 ]]; then
+  echo "Connection closed mid-restart — this is normal."
+elif [[ "$curl_rc" -ne 0 ]]; then
+  echo "curl failed (exit $curl_rc)" >&2; exit 1
+elif [[ "$code" == 401 || "$code" == 403 || "$code" == 404 ]]; then
+  echo "Restart API returned HTTP $code — check HA_URL and HA_TOKEN." >&2; exit 1
+fi
+
+echo "Done. Give Home Assistant a minute to finish restarting."

--- a/custom_components/magister_school/sensor.py
+++ b/custom_components/magister_school/sensor.py
@@ -1,5 +1,6 @@
 # sensor.py
 import logging
+from datetime import datetime
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -31,19 +32,25 @@ async def async_setup_entry(
     
     async_add_entities(sensors, update_before_add=False)
 
+def _get_school_lessen(kind_data):
+    """Return actual school lessons, excluding homework and cancelled items."""
+    afspraken = kind_data.get("afspraken", []) if kind_data else []
+    return [a for a in afspraken if not a.get("is_huiswerk") and not a.get("is_uitval")]
+
+
 def create_kind_sensors(coordinator, kind_naam):
     """Maak alle individuele sensors aan voor een kind."""
     base_id = kind_naam.lower().replace(' ', '_')
-    
+
     return [
         # Overview sensor voor templates (deze moet erbij!)
         KindOverviewSensor(coordinator, kind_naam, base_id),
-        
+
         # Basis info sensors
         KindAantalAfsprakenSensor(coordinator, kind_naam, base_id),
         KindAantalHuiswerkSensor(coordinator, kind_naam, base_id),
         KindVolgendeAfspraakSensor(coordinator, kind_naam, base_id),
-        
+
         # Detail sensors
         KindCijfersSensor(coordinator, kind_naam, base_id),
         KindAfsprakenSensor(coordinator, kind_naam, base_id),
@@ -53,6 +60,13 @@ def create_kind_sensors(coordinator, kind_naam):
         KindStudiewijzersSensor(coordinator, kind_naam, base_id),
         KindActiviteitenSensor(coordinator, kind_naam, base_id),
         KindAanmeldingenSensor(coordinator, kind_naam, base_id),
+
+        # Agenda sensors
+        KindSchoolStartVandaagSensor(coordinator, kind_naam, base_id),
+        KindSchoolEindeVandaagSensor(coordinator, kind_naam, base_id),
+        KindVolgendeScooldagSensor(coordinator, kind_naam, base_id),
+        KindVolgendeScooldagStartSensor(coordinator, kind_naam, base_id),
+        KindVolgendeScooldagEindeSensor(coordinator, kind_naam, base_id),
     ]
 
 class KindOverviewSensor(SensorEntity):
@@ -623,7 +637,7 @@ class KindActiviteitenSensor(SensorEntity):
 
 class KindAanmeldingenSensor(SensorEntity):
     """Sensor voor aanmeldingen."""
-    
+
     def __init__(self, coordinator, kind_naam, base_id):
         self._coordinator = coordinator
         self._kind_naam = kind_naam
@@ -644,6 +658,255 @@ class KindAanmeldingenSensor(SensorEntity):
             "kind_naam": self._kind_naam,
             "aanmeldingen": kind_data.get("aanmeldingen", []) if kind_data else []
         }
+
+    def _get_kind_data(self):
+        if not self._coordinator.data:
+            return None
+        return self._coordinator.data.get("kinderen", {}).get(self._kind_naam)
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def available(self):
+        return self._coordinator.last_update_success and self._get_kind_data() is not None
+
+    async def async_update(self):
+        await self._coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            self._coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+
+# Agenda sensors
+class KindSchoolStartVandaagSensor(SensorEntity):
+    """Begintijd van de eerste les vandaag."""
+
+    def __init__(self, coordinator, kind_naam, base_id):
+        self._coordinator = coordinator
+        self._kind_naam = kind_naam
+        self._attr_unique_id = f"magister_{base_id}_school_start_vandaag"
+        self._attr_name = f"Magister {kind_naam} School Start Vandaag"
+        self._attr_icon = "mdi:clock-start"
+
+    @property
+    def state(self):
+        kind_data = self._get_kind_data()
+        lessen = _get_school_lessen(kind_data)
+        vandaag = datetime.now().date()
+        dag_lessen = [l for l in lessen if datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date() == vandaag]
+        if not dag_lessen:
+            return "Geen"
+        return min(datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S") for l in dag_lessen).strftime("%H:%M")
+
+    @property
+    def extra_state_attributes(self):
+        return {"kind_naam": self._kind_naam}
+
+    def _get_kind_data(self):
+        if not self._coordinator.data:
+            return None
+        return self._coordinator.data.get("kinderen", {}).get(self._kind_naam)
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def available(self):
+        return self._coordinator.last_update_success and self._get_kind_data() is not None
+
+    async def async_update(self):
+        await self._coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            self._coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+
+class KindSchoolEindeVandaagSensor(SensorEntity):
+    """Eindtijd van de laatste les vandaag."""
+
+    def __init__(self, coordinator, kind_naam, base_id):
+        self._coordinator = coordinator
+        self._kind_naam = kind_naam
+        self._attr_unique_id = f"magister_{base_id}_school_einde_vandaag"
+        self._attr_name = f"Magister {kind_naam} School Einde Vandaag"
+        self._attr_icon = "mdi:clock-end"
+
+    @property
+    def state(self):
+        kind_data = self._get_kind_data()
+        lessen = _get_school_lessen(kind_data)
+        vandaag = datetime.now().date()
+        dag_lessen = [l for l in lessen if datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date() == vandaag]
+        if not dag_lessen:
+            return "Geen"
+        return max(datetime.strptime(l["einde"], "%Y-%m-%d %H:%M:%S") for l in dag_lessen).strftime("%H:%M")
+
+    @property
+    def extra_state_attributes(self):
+        return {"kind_naam": self._kind_naam}
+
+    def _get_kind_data(self):
+        if not self._coordinator.data:
+            return None
+        return self._coordinator.data.get("kinderen", {}).get(self._kind_naam)
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def available(self):
+        return self._coordinator.last_update_success and self._get_kind_data() is not None
+
+    async def async_update(self):
+        await self._coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            self._coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+
+class KindVolgendeScooldagSensor(SensorEntity):
+    """Datum van de eerstvolgende schooldag na vandaag."""
+
+    def __init__(self, coordinator, kind_naam, base_id):
+        self._coordinator = coordinator
+        self._kind_naam = kind_naam
+        self._attr_unique_id = f"magister_{base_id}_volgende_schooldag"
+        self._attr_name = f"Magister {kind_naam} Volgende Schooldag"
+        self._attr_icon = "mdi:calendar-arrow-right"
+
+    def _volgende_dag(self):
+        kind_data = self._get_kind_data()
+        lessen = _get_school_lessen(kind_data)
+        vandaag = datetime.now().date()
+        toekomstige_data = {
+            datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date()
+            for l in lessen
+            if datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date() > vandaag
+        }
+        return min(toekomstige_data) if toekomstige_data else None
+
+    @property
+    def state(self):
+        dag = self._volgende_dag()
+        return dag.strftime("%Y-%m-%d") if dag else "Geen"
+
+    @property
+    def extra_state_attributes(self):
+        return {"kind_naam": self._kind_naam}
+
+    def _get_kind_data(self):
+        if not self._coordinator.data:
+            return None
+        return self._coordinator.data.get("kinderen", {}).get(self._kind_naam)
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def available(self):
+        return self._coordinator.last_update_success and self._get_kind_data() is not None
+
+    async def async_update(self):
+        await self._coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            self._coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+
+class KindVolgendeScooldagStartSensor(SensorEntity):
+    """Begintijd van de eerste les op de eerstvolgende schooldag."""
+
+    def __init__(self, coordinator, kind_naam, base_id):
+        self._coordinator = coordinator
+        self._kind_naam = kind_naam
+        self._attr_unique_id = f"magister_{base_id}_volgende_schooldag_start"
+        self._attr_name = f"Magister {kind_naam} Volgende Schooldag Start"
+        self._attr_icon = "mdi:clock-start"
+
+    @property
+    def state(self):
+        kind_data = self._get_kind_data()
+        lessen = _get_school_lessen(kind_data)
+        vandaag = datetime.now().date()
+        toekomstige_data = {
+            datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date()
+            for l in lessen
+            if datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date() > vandaag
+        }
+        if not toekomstige_data:
+            return "Geen"
+        volgende_dag = min(toekomstige_data)
+        dag_lessen = [l for l in lessen if datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date() == volgende_dag]
+        return min(datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S") for l in dag_lessen).strftime("%H:%M")
+
+    @property
+    def extra_state_attributes(self):
+        return {"kind_naam": self._kind_naam}
+
+    def _get_kind_data(self):
+        if not self._coordinator.data:
+            return None
+        return self._coordinator.data.get("kinderen", {}).get(self._kind_naam)
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def available(self):
+        return self._coordinator.last_update_success and self._get_kind_data() is not None
+
+    async def async_update(self):
+        await self._coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self):
+        self.async_on_remove(
+            self._coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+
+class KindVolgendeScooldagEindeSensor(SensorEntity):
+    """Eindtijd van de laatste les op de eerstvolgende schooldag."""
+
+    def __init__(self, coordinator, kind_naam, base_id):
+        self._coordinator = coordinator
+        self._kind_naam = kind_naam
+        self._attr_unique_id = f"magister_{base_id}_volgende_schooldag_einde"
+        self._attr_name = f"Magister {kind_naam} Volgende Schooldag Einde"
+        self._attr_icon = "mdi:clock-end"
+
+    @property
+    def state(self):
+        kind_data = self._get_kind_data()
+        lessen = _get_school_lessen(kind_data)
+        vandaag = datetime.now().date()
+        toekomstige_data = {
+            datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date()
+            for l in lessen
+            if datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date() > vandaag
+        }
+        if not toekomstige_data:
+            return "Geen"
+        volgende_dag = min(toekomstige_data)
+        dag_lessen = [l for l in lessen if datetime.strptime(l["start"], "%Y-%m-%d %H:%M:%S").date() == volgende_dag]
+        return max(datetime.strptime(l["einde"], "%Y-%m-%d %H:%M:%S") for l in dag_lessen).strftime("%H:%M")
+
+    @property
+    def extra_state_attributes(self):
+        return {"kind_naam": self._kind_naam}
 
     def _get_kind_data(self):
         if not self._coordinator.data:


### PR DESCRIPTION
## What this adds

Five new sensors per child, derived from the existing `Afspraken` data:

| Sensor | State |
|---|---|
| `School Start Vandaag` | Start time of the first lesson today |
| `School Einde Vandaag` | End time of the last lesson today |
| `Volgende Schooldag` | Date of the next school day |
| `Volgende Schooldag Start` | Start time of the first lesson on that day |
| `Volgende Schooldag Einde` | End time of the last lesson on that day |

Times are in 24h notation (`HH:MM`). The date is in `YYYY-MM-DD` format. When there are no lessons, the state is `Geen`.

## How it works

The sensors filter the existing `afspraken` list, excluding homework items
(`is_huiswerk: true`) and cancelled lessons (`is_uitval: true`), so only
actual school hours are reflected.

No new API calls are made — everything is computed from data the coordinator
already fetches.

## Non-breaking

Only new sensors are added. No existing sensors or behavior is changed.

---

I'm a new user of this integration. I'm using it to show the start and end times of my children on an e-ink dashboard that I have in my living room.  
This PR does not yet update the documentation. I'm curious to hear what you think of this. If you want me to make any adjustments before merging let me know!


