### PR TITLE
Fix whole-day events skewing school start/end times

### DIFF
--- a/custom_components/magister_school/magister.py
+++ b/custom_components/magister_school/magister.py
@@ -693,7 +693,7 @@ def main():
         vandaag = datetime.now().strftime('%Y-%m-%d')
         kind_data["aantal_afspraken_vandaag"] = len([
             a for a in kind_data["afspraken"]
-            if a["start"].startswith(vandaag)
+            if a["start"].startswith(vandaag) and not a["start"].endswith(" 00:00:00")
         ])
         kind_data["aantal_huiswerk"] = len([
             a for a in kind_data["afspraken"]

--- a/custom_components/magister_school/sensor.py
+++ b/custom_components/magister_school/sensor.py
@@ -33,9 +33,14 @@ async def async_setup_entry(
     async_add_entities(sensors, update_before_add=False)
 
 def _get_school_lessen(kind_data):
-    """Return actual school lessons, excluding homework and cancelled items."""
+    """Return actual school lessons, excluding homework, cancelled, and whole-day items."""
     afspraken = kind_data.get("afspraken", []) if kind_data else []
-    return [a for a in afspraken if not a.get("is_huiswerk") and not a.get("is_uitval")]
+    return [
+        a for a in afspraken
+        if not a.get("is_huiswerk")
+        and not a.get("is_uitval")
+        and not a.get("start", "").endswith(" 00:00:00")
+    ]
 
 
 def create_kind_sensors(coordinator, kind_naam):


### PR DESCRIPTION
## Bug fix

Whole-day events (e.g. "laptop mee") are stored with `start` and `einde` at `00:00:00`, which caused them to be picked up as the earliest lesson of the day, pulling the school start time to `00:00`.

## Fix

Added a check in `_get_school_lessen` to exclude any appointment where the start time is midnight, in addition to the existing homework and uitval filters:

```python
and not a.get("start", "").endswith(" 00:00:00")
```

This is a follow-up to the agenda sensors PR.