### PR TITLE
Fix school start/end times excluding lessons with homework

### DIFF
--- a/custom_components/magister_school/sensor.py
+++ b/custom_components/magister_school/sensor.py
@@ -33,9 +33,15 @@ async def async_setup_entry(
     async_add_entities(sensors, update_before_add=False)
 
 def _get_school_lessen(kind_data):
-    """Return actual school lessons, excluding homework and cancelled items."""
+    """Return actual school lessons (soort 'Les'), excluding cancelled items.
+
+    Filter on ``soort`` rather than ``is_huiswerk``: a lesson that has homework
+    attached (InfoType 1) is still a real lesson, and using ``is_huiswerk`` would
+    wrongly drop it. This also excludes non-lesson items like all-day notices and
+    "Inloopspreekuur" (soort "Algemeen") from school start/end times.
+    """
     afspraken = kind_data.get("afspraken", []) if kind_data else []
-    return [a for a in afspraken if not a.get("is_huiswerk") and not a.get("is_uitval")]
+    return [a for a in afspraken if a.get("soort") == "Les" and not a.get("is_uitval")]
 
 
 def _parse_school_datetime(value):


### PR DESCRIPTION
## Problem

The agenda sensors report the wrong school start and end times when the first/last lesson of the day has homework or when the day contains non-lesson items.

`_get_school_lessen()` filtered appointments by `is_huiswerk`, but that flag is just `InfoType == 1` from Magister — it means a lesson **has homework attached**, not that the appointment *is* a homework item. So whenever the first lesson of the day had homework, it was discarded and the sensor reported the *second* lesson's start time.

The same filter also kept non-lesson appointments (`soort == "Algemeen"`) such as all-day notices and "Inloopspreekuur", which pushed `school_einde` past the last real lesson.

## Fix

Filter on `soort == "Les"` instead of `is_huiswerk`. This correctly:
- **includes** lessons that have homework attached (they are real lessons),
- **excludes** non-lesson items like all-day notices and "Inloopspreekuur",
- still **excludes** cancelled lessons via `is_uitval`.

## Example

Real-world day where the first lesson (09:30, "wi – dalp") had homework and the day ended with a 13:00–15:00 "Inloopspreekuur":

| Sensor | Before | After (matches Magister) |
|---|---|---|
| `volgende_schooldag_start` | 10:00 | **09:30** |
| `volgende_schooldag_einde` | 15:00 | **12:30** |

This affects `school_start_vandaag`, `school_einde_vandaag`, `volgende_schooldag_start`, `volgende_schooldag_einde`, and the `lessen_vandaag` card list, all of which share this helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)